### PR TITLE
Fix restart issues

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -259,7 +259,7 @@ function _restart!(s, k = 10)
     empty_tabu!(s)
     δ = ((k - 1) * get_option(s, "tabu_delta")) + get_option(s, "tabu_time") / k
     set_option!(s, "tabu_delta", δ)
-    _compute!(s) ? _optimizing!(s) : _satisfying!(s)
+    (_compute!(s) && !is_sat(s)) ? _optimizing!(s) : _satisfying!(s)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,6 @@ const LS = LocalSearchSolvers
 @testset "LocalSearchSolvers.jl" begin
     include("Aqua.jl")
     include("TestItemRunner.jl")
-    # include("internal.jl")
-    # include("raw_solver.jl")
+    include("internal.jl")
+    include("raw_solver.jl")
 end


### PR DESCRIPTION
Solver was set to optimizing even when no objectives were provided at restart.