### PR TITLE
Use coordinate descent for continuous variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,8 +30,9 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "Test", "TestItemRunner"]
+test = ["Aqua", "Intervals", "Test", "TestItemRunner"]


### PR DESCRIPTION
This draft PR implements coordinate search for continuous variables in place of the current random search.
The objective function is assumed to be $C^1$ w.r.t. the continuous variables. Gradients are (momentarily) estimated via a simple finite difference method.
The algorithm uses the [Armijo line search criterion](https://en.wikipedia.org/wiki/Backtracking_line_search) to determine the step size. 

The following features should be implemented before marking for review.
- [x] Implement a basic line search algorithm for coordinate descent on continuous variables
- [ ] Integrate the coordinate descent algorithm with the management of the Tabu list
- [ ] Add a test for a continuous problem (e.g., chemical equilibrium from [ConstraintModels.jl](https://github.com/JuliaConstraints/ConstraintModels.jl)) and check for convergence. The test should fail on the current version of the package